### PR TITLE
Add rename option for both project and module

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,56 +13,100 @@ sudo python3 install.py
 This will create a symbolic link in `/usr/local/bin`.
 
 ### Usage
+The cpm has two options - `project` and `module`. The general usage syntax looks like this:
 ```
-cpm [-h] [-m] [-d] name
+cpm [-h] {project,module} ...
 ```
-Arguments can be combined. These two lines will have exactly the same result:
-```
-cpm -m -d gpio
-cpm -md gpio
-```
-
-
-If there are no optional arguments present then the script will create a base for the project with the following content:
-* src and build folders
-* makefile
-* main.c file with the following content
-    ```c
-    #include <stdlib.h>
+#### Project
+The `project` option is responsible for managing a C project. This includes:
+* Creating a project with:
+    * makefile
+    * build directory
+    * src directory
+    * main.c inside src
     
-    int main(int argc, char *argv[])
-    {
-        return 0;
-    }
-    ```
-By using the -m or --module argument the script will instead create a module with the given name in the current working
-directory. For example the following:
+    In this case the program only expects one positional argument `name`.
+* Renaming a project. To do this, `-r`/`--rename` argument must be used. The argument expects an existing module name to be given.
+
+The created makefile will have the following content:
+```makefile
+# Compiler:
+CC = gcc
+
+# C flags:
+CFLAGS = -g -Wall -pedantic
+
+# Directory with all the source files:
+SRC = src
+# Find all subdirectories inside the SRC directory. Remove ./ with subst.
+VPATH = $(shell find $(SRC) -type d)
+
+# Directory with where the compiled files go:
+OBJ = build
+
+# Find all .c files
+SOURCES = $(subst ./,,$(shell find . -name "*.c"))
+# Use $(notdir ...) to get only the filenames (ignore the directories)
+# Delete file extensions with $(basename ...)
+FILENAMES = $(basename $(notdir $(SOURCES)))
+# All objects will be stored inside OBJ directory, without any sub-directories
+# so, once we have the filenames we just simply add the .o suffix to them
+# then, add the $(OBJ)/ prefix to put them inside the directory
+OBJECTS = $(addprefix $(OBJ)/, $(addsuffix .o, $(FILENAMES)))
+
+.PHONY: all
+all: $(OBJECTS)
+	$(CC) -o $(OBJ)/[PROJECT_NAME] $(OBJECTS)
+
+$(OBJ)/%.o: %.c
+	$(CC) -c $< $(CFLAGS) -o $@
+
+.PHONY: clean
+clean:
+	@echo "Deleting all compiled files..."
+	rm -f $(OBJ)/*
+	@echo "Done."
 ```
-cpm -m gpio
-```
-will create two files, **gpio.h** with the following content:
+**main.c** will have:
 ```c
-#ifndef GPIO_H
-#define GPIO_H
+#include <stdlib.h>
+
+int main(int argc, char *argv[])
+{
+    return 0;
+}
+```
+The usage syntax for `project` option is:
+```
+cpm project [-h] [-r old_name] name
+```
+#### Module
+The `module` option is responsible for managing a C module - source and header files and optionally, a directory. 
+
+The usage syntax for the `module` option is:
+```
+cpm module [-h] [-r old_name | -d] name
+```
+This option has three functions:
+* Create source and header files with the given name in the current working directory
+* (With `-d`/`--directory`) Create directory with the given name, then create source and header files inside that directory.
+* (With `-r`/`--rename`) Rename module. Scan all source files inside **src** directory and update includes where applicable
+
+The source file created will have the following content:
+```c
+#include "[NAME].h"
+
+```
+The header file will be:
+```c
+#ifndef [NAME]_H
+#define [NAME]_H
 
 
 
 #endif
 ```
-and **gpio.c**:
-```c
-#include "gpio.h"
-
-
-```
-
-
-A special option available only when creating module is the -d or --directory option. This will create a separate 
-directory for the module. For example:
-```
-cpm -md gpio
-```
-will create a new **gpio** directory with **gpio.c** and **gpio.h** inside.
+Where in both cases `[NAME]` is the name passed as an argument.
 ## Uninstalling
 If for some reason you want to uninstall the cpm you can do this using the `install.py` script. 
 This is done by adding `remove` argument:

--- a/project/cpm
+++ b/project/cpm
@@ -18,7 +18,7 @@ def main():
     # Before executing any sub-parser handlers (like project_args_handler)
     # the name and rename (if used) are validated.
     # If any of these names are invalid, the program will terminate
-    if hasattr(args, 'rename') and not valid_name(args.rename):
+    if hasattr(args, 'rename') and args.rename is not None and not valid_name(args.rename):
         print_invalid_name_error(args.rename)
         return
 

--- a/project/cpm
+++ b/project/cpm
@@ -23,10 +23,12 @@ def main():
         print("Directory argument requires module argument to be preset as well")
         return
 
-    if not args.module:
-        project.create_project(args.name)
-    else:
+    if args.module:
         module.create_module(args.name, args.directory)
+    elif args.rename:
+        project.rename(args.rename, args.name)
+    else:
+        project.create_project(args.name)
 
 
 def setup_arg_parser():
@@ -44,6 +46,7 @@ def setup_arg_parser():
                                                         "Note that this argument requires the module argument "
                                                         "to be preset as well",
                               action="store_true")
+    arg_parser.add_argument("-r", "--rename", help="rename an existing project to [name]", metavar='old_name')
     return arg_parser
 
 

--- a/project/cpm
+++ b/project/cpm
@@ -15,20 +15,52 @@ def main():
     arg_parser = setup_arg_parser()
     args = arg_parser.parse_args()
 
+    # Before executing any sub-parser handlers (like project_args_handler)
+    # the name and rename (if used) are validated.
+    # If any of these names are invalid, the program will terminate
+    if args.rename is not None and not valid_name(args.rename):
+        print_invalid_name_error(args.rename)
+        return
+
     if not valid_name(args.name):
-        print("The name " + args.name + " is not valid. Only alphanumerical characters are accepted.")
+        print_invalid_name_error(args.name)
         return
 
-    if args.directory and not args.module:
-        print("Directory argument requires module argument to be preset as well")
-        return
+    # args.function will call the right args handler depending on the specified argument
+    # For example, if the user executes the program like:
+    # cpm project foo
+    # Then the arg parser will call project_args_handler to handle the arguments
+    args.function(args)
 
-    if args.module:
-        module.create_module(args.name, args.directory)
-    elif args.rename:
+
+def print_invalid_name_error(name):
+    """
+    Print an invalid name error
+    :param name: Invalid name
+    """
+    print("The name " + name + " is not valid. Only alphanumerical characters are accepted.")
+
+
+def project_args_handler(args):
+    """
+    Handle the arguments when project option is used
+    :param args: Parsed arguments
+    """
+    if args.rename:
         project.rename(args.rename, args.name)
     else:
         project.create_project(args.name)
+
+
+def module_args_handler(args):
+    """
+    Handle the arguments when module option is used
+    :param args: Parsed arguments
+    """
+    if args.rename:
+        print("Renaming module is not implemented yet!")
+    else:
+        module.create_module(args.name, args.directory)
 
 
 def setup_arg_parser():
@@ -37,17 +69,43 @@ def setup_arg_parser():
     :return: ArgumentParser with supported arguments
     """
     arg_parser = argparse.ArgumentParser()
-    arg_parser.add_argument("name", help="create a project with the given name if the module option (-m or --module)"
-                                         " is not specified. The name must consist of only alphanumerical characters")
-    module_group = arg_parser.add_argument_group()
-    module_group.add_argument("-m", "--module", help="create a module (.c and .h files) with the specified name",
-                              action="store_true")
-    module_group.add_argument("-d", "--directory", help="create a directory for the module. "
-                                                        "Note that this argument requires the module argument "
-                                                        "to be preset as well",
-                              action="store_true")
-    arg_parser.add_argument("-r", "--rename", help="rename an existing project to [name]", metavar='old_name')
+    subparsers = arg_parser.add_subparsers(help="available options")
+    setup_project_parser(subparsers)
+    setup_module_parser(subparsers)
     return arg_parser
+
+
+def setup_project_parser(subparsers):
+    """
+    Set up the project option and all its arguments
+    :param subparsers: subparsers of the argument parser
+    """
+    parser = subparsers.add_parser('project', help='creates/renames a project')
+    parser.add_argument('-r', '--rename', help='rename project with [old_name] to [name]', metavar='old_name')
+    parser.add_argument("name", help="target project name")
+    # Set a function that will be called to handle the arguments
+    parser.set_defaults(function=project_args_handler)
+
+
+def setup_module_parser(subparsers):
+    """
+    Set up the module option and all its arguments
+    :param subparsers: subparsers of the argument parser
+    """
+    parser = subparsers.add_parser('module', help='creates/renames a module (source + header files)')
+
+    # Because it does not make sense to have rename and directory arguments present at the same time
+    # (it wouldn't be clear what the user wants to achieve)
+    # mutually exclusive group will tell the parser that only one option from that group can be used at a time.
+    mutually_exclusive = parser.add_mutually_exclusive_group()
+    mutually_exclusive.add_argument('-r', '--rename', help='rename module with [old_name] to [name]',
+                                    metavar='old_name')
+    mutually_exclusive.add_argument('-d', '--directory', action='store_true',
+                                    help='create directory for the module')
+
+    parser.add_argument('name', help='target module name')
+    # Set a function that will be called to handle the arguments
+    parser.set_defaults(function=module_args_handler)
 
 
 def valid_name(name):

--- a/project/cpm
+++ b/project/cpm
@@ -64,7 +64,7 @@ def module_args_handler(args):
     :param args: Parsed arguments
     """
     if args.rename:
-        print("Renaming module is not implemented yet!")
+        module.rename(args.rename, args.name)
     else:
         module.create_module(args.name, args.directory)
 

--- a/project/cpm
+++ b/project/cpm
@@ -18,11 +18,17 @@ def main():
     # Before executing any sub-parser handlers (like project_args_handler)
     # the name and rename (if used) are validated.
     # If any of these names are invalid, the program will terminate
-    if args.rename is not None and not valid_name(args.rename):
+    if hasattr(args, 'rename') and not valid_name(args.rename):
         print_invalid_name_error(args.rename)
         return
 
-    if not valid_name(args.name):
+    # If the user has not used any option (executed cpm without any arguments)
+    # print the help message and terminate
+    if not hasattr(args, 'name'):
+        arg_parser.print_help()
+        return
+
+    if hasattr(args, 'name') and not valid_name(args.name):
         print_invalid_name_error(args.name)
         return
 

--- a/project/project.py
+++ b/project/project.py
@@ -71,4 +71,4 @@ def rename(old, new):
     os.rename(old, new)
     makefile_path = (os.path.join(os.getcwd(), new, "makefile"))
     for line in fileinput.input(makefile_path, inplace=True):
-        print(line.replace(old, new))
+        print(line.replace(old, new), end='')  # Change the end to an empty string, otherwise it will put another \n.

--- a/project/project.py
+++ b/project/project.py
@@ -1,5 +1,6 @@
 import errno
 import os
+import fileinput
 from shutil import copyfile
 
 directory = ""
@@ -61,3 +62,13 @@ def create_project(project_name):
     if create_folders(project_name):
         create_main_file()
         create_makefile()
+
+
+def rename(old, new):
+    if not os.path.isdir(os.path.join(os.getcwd(), old)):
+        print("Project {} does not exist".format(old))
+
+    os.rename(old, new)
+    makefile_path = (os.path.join(os.getcwd(), new, "makefile"))
+    for line in fileinput.input(makefile_path, inplace=True):
+        print(line.replace(old, new))

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,5 +1,6 @@
 import unittest
-from project.module import match_and_replace_include as replace_include
+from project.module import rename_in_include as replace_include
+from project.module import rename_header_constant as replace_header
 
 class ModuleTest(unittest.TestCase):
     """
@@ -9,7 +10,6 @@ class ModuleTest(unittest.TestCase):
     def test_include_regex(self):
         """
         Test the include regex used to find and replace #include... when renaming the module
-        :return:
         """
         tests = [
             {
@@ -37,3 +37,31 @@ class ModuleTest(unittest.TestCase):
         for test in tests:
             with self.subTest(original=test['original']):
                 self.assertEqual(test['expected'], replace_include(test['original'], 'foo', 'bar'))
+
+
+    def test_header_regex(self):
+        """
+        Test the header regex used to find and replace include-guard-constants inside a header
+        """
+        tests = [
+            {
+                'original': '#ifndef FOO_H',
+                'expected': '#ifndef BAR_H'
+            },
+            {
+                'original': '#define FOO_H',
+                'expected': '#define BAR_H'
+            },
+            {
+                'original': '#endif /* FOO_H */',
+                'expected': '#endif /* BAR_H */',
+            },
+            {
+                'original': '// Lorem ipsum FOO_H dolor sit amet',
+                'expected': '// Lorem ipsum BAR_H dolor sit amet'
+            },
+        ]
+
+        for test in tests:
+            with self.subTest(original=test['original']):
+                self.assertEqual(test['expected'], replace_header(test['original'], 'foo', 'bar'))

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -1,0 +1,39 @@
+import unittest
+from project.module import match_and_replace_include as replace_include
+
+class ModuleTest(unittest.TestCase):
+    """
+    Provides tests for the module.py script
+    """
+
+    def test_include_regex(self):
+        """
+        Test the include regex used to find and replace #include... when renaming the module
+        :return:
+        """
+        tests = [
+            {
+                'original': '#include "foo.h"',
+                'expected': '#include "bar.h"',
+            },
+            {
+                'original': '#include "foo/foo.h"',
+                'expected': '#include "bar/bar.h"',
+            },
+            {
+                'original': '#include "../foo/foo.h"',
+                'expected': '#include "../bar/bar.h"',
+            },
+            {
+                'original': '#include "../xyz/foo.h"',
+                'expected': '#include "../xyz/bar.h"',
+            },
+            {
+                'original': '#include "../xyz/foo/foo.h"',
+                'expected': '#include "../xyz/bar/bar.h"',
+            },
+        ]
+
+        for test in tests:
+            with self.subTest(original=test['original']):
+                self.assertEqual(test['expected'], replace_include(test['original'], 'foo', 'bar'))


### PR DESCRIPTION
The commits included in this pull request will change how the **cpm** is used. Now, instead of using optional argument to create a module there are two options - `project` and `module`. These are actually independent sub-parsers so the optional arguments that `project` supports may not be supported by `module`.
The syntax and basic how-to is inside README.md. More information can also be found by using `-h` option: `cpm -h` for general help, `cpm project -h` for `project` help and `cpm module -h` for `module` help.

To summarise the pull request, the commits add the following functionalities:
- sub-parsers as options (`project` and `module`)
- renaming a project
- renaming a module and updating all source files that include it