### PR TITLE
Fix tests loading and assertions

### DIFF
--- a/tests/loader.py
+++ b/tests/loader.py
@@ -9,7 +9,7 @@ def load(module):
     if len(module) == 0:
         raise ValueError("Module name cannot be empty")
 
-    spec = spec_from_loader(module, SourceFileLoader(module, "../project/" + module))
+    spec = spec_from_loader(module, SourceFileLoader(module, "../scripts/" + module))
     module = module_from_spec(spec)
     spec.loader.exec_module(module)
     return module

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -37,7 +37,7 @@ class ModuleTest(unittest.TestCase):
 
         for test in tests:
             with self.subTest(original=test['original']):
-                self.assertEqual(test['expected'], replace_include(test['original'], 'foo', 'bar'))
+                self.assertEqual(test['expected'], replace_include(test['original'], 'foo', 'bar')[0])
 
     def test_header_regex(self):
         """


### PR DESCRIPTION
- Update **tests/loader.py** after the **project** directory has been renamed to **scripts**
- `replace_include` returns a tuple with modified line as the first element, and bool (indicating whether there have been any changes made) as the second. Fix the regex test to test the first element.